### PR TITLE
Update 02_verwendung_dieses_buches.ipynb

### DIFF
--- a/content/00_einleitung/02_verwendung_dieses_buches.ipynb
+++ b/content/00_einleitung/02_verwendung_dieses_buches.ipynb
@@ -92,10 +92,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {
     "tags": [
-     "thebe_init"
+     "thebe-init"
     ]
    },
    "outputs": [],
@@ -111,9 +111,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "tags": [
-     "thebe_init"
-    ]
+    "tags": []
    },
    "outputs": [
     {
@@ -168,7 +166,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Created file '/home/user/Modellbildung-und-Simulation/content/00_einleitung/02_usage/fac.m'.\n"
+      "Created file 'fac.m'.\n"
      ]
     }
    ],
@@ -188,15 +186,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "hide_input",
-     "thebe_init"
+     "thebe-init"
     ]
    },
    "outputs": [],
    "source": [
+    "%%file test_fac.m\n",
     "function test_suite=test_fac\n",
     "% initialize unit tets\n",
     "    try\n",
@@ -264,7 +263,7 @@
     }
    ],
    "source": [
-    "moxunit_runtests ../test_fac.m"
+    "moxunit_runtests test_fac.m"
    ]
   },
   {
@@ -285,7 +284,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Created file '/home/user/Modellbildung-und-Simulation/content/00_einleitung/02_usage/fac.m'.\n"
+      "Created file 'fac.m'.\n"
      ]
     }
    ],
@@ -342,7 +341,7 @@
     }
    ],
    "source": [
-    "moxunit_runtests ../test_fac.m"
+    "moxunit_runtests test_fac.m"
    ]
   },
   {
@@ -369,7 +368,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "../test_fac.m is the user-defined function defined from: /home/user/Modellbildung-und-Simulation/content/00_einleitung/test_fac.m\n",
+      "test_fac.m is the user-defined function defined from: /home/user/Modellbildung-und-Simulation/content/00_einleitung/test_fac.m\n",
       "\n",
       "function test_suite=test_fac\n",
       "% initialize unit tets\n",
@@ -415,7 +414,7 @@
     }
    ],
    "source": [
-    "type ../test_fac.m"
+    "type test_fac.m"
    ]
   },
   {


### PR DESCRIPTION
# Description

- trying tag `thebe-init` instead of `thebe_init` - may be same as in thebe, though `hide_input` also works with underscore here
- removed `../` from paths, as it can be assumed that our files will not be found.
- related to #544 

## Checklist

 - [x] This pull request is associated to an issue