### PR TITLE
Update environment.yml

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -2,3 +2,4 @@ dependencies:
 - numpy
 - matplotlib
 - octave_kernel
+- font-manager


### PR DESCRIPTION
# Description

Figure in intro.ipynb could not load FreeFont (`ft_manager: unable to load font: /usr/share/fonts/opentype/freefont/FreeSans.otf`)

## Checklist

 - [ ] This pull request is associated to an issue
 - [ ] All used resources use a CC BY-SA 4.0 license or less and are marked appropriately, see our [contribution guide](https://github.com/hbrs-cse/Modellbildung-und-Simulation/blob/master/CONTRIBUTING.md).
 - [ ] All used resources have been added to [the one spreadsheet](https://docs.google.com/spreadsheets/d/1VzA6rIrLjV0GJee_7CQShjTJ-w86xugP6vsIzDmNSGs/edit#gid=763219261)
 - [ ] New exercises include learning requirements and learning goals.
 - [ ] Add someone else as reviewer and wait for approval before merging.
